### PR TITLE
feat: change to non-primary provider

### DIFF
--- a/Contents/Code/__init__.py
+++ b/Contents/Code/__init__.py
@@ -168,8 +168,8 @@ def loadStaticMediaTVShows(metadata, media):
 class StaticMediaAgent(Agent.Movies):
   name = 'Static Media'
   languages = [Locale.Language.NoLanguage]
-  primary_provider = True
-  accepts_from = ['com.plexapp.agents.localmedia']
+  primary_provider = False
+  contributes_to = ['com.plexapp.agents.none']
 
   def search(self, results, media, lang):
     Log('[STATIC] Searching for %s' % media.name)
@@ -181,8 +181,8 @@ class StaticMediaAgent(Agent.Movies):
 class StaticMediaAgent(Agent.TV_Shows):
   name = 'Static Media'
   languages = [Locale.Language.NoLanguage]
-  primary_provider = True
-  accepts_from = ['com.plexapp.agents.localmedia']
+  primary_provider = False
+  contributes_to = ['com.plexapp.agents.none']
 
   def search(self, results, media, lang):
     Log('[STATIC] Searching for %s' % media.show)


### PR DESCRIPTION
With this change the agent shows up in the Agents settings under Movies -> Personal Media and Shows -> Personal Media Shows.

With this change the plugin also doesn't change the media library type from Other Videos to Movies for me.

I put Static Media in the last place and it still nicely finds the files for my F1 library (type Other Videos).